### PR TITLE
Fix Relay Connection ID

### DIFF
--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -282,6 +282,8 @@ class QueryOptimizer(object):
                 resolver_fn = arg
             if isinstance(resolver_fn, functools.partial) and resolver_fn.func == default_resolver:
                 return resolver_fn.args[0]
+            if self._is_resolver_for_id_field(resolver_fn):
+                return 'id'
             return resolver_fn
 
     def _is_resolver_for_id_field(self, resolver):

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -1,6 +1,6 @@
 from django.db.models import Prefetch
 import graphene
-from graphene import ConnectionField
+from graphene import ConnectionField, relay
 from graphene_django.fields import DjangoConnectionField
 import graphene_django_optimizer as gql_optimizer
 from graphene_django_optimizer import OptimizedDjangoObjectType
@@ -38,8 +38,8 @@ class ItemFilterInput(graphene.InputObjectType):
 
 
 class ItemInterface(graphene.Interface):
-    id = graphene.ID(required=True)
-    parent_id = graphene.ID()
+    id = relay.GlobalID()
+    parent_id = relay.GlobalID()
     foo = graphene.String()
     title = graphene.String()
     unoptimized_title = graphene.String()

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -19,6 +19,7 @@ def test_should_return_valid_result_in_a_relay_query():
                 edges {
                     node {
                         id
+                        parentId
                         name
                     }
                 }
@@ -26,7 +27,8 @@ def test_should_return_valid_result_in_a_relay_query():
         }
     ''')
     assert not result.errors
-    assert result.data['relayItems']['edges'][0]['node']['id'] == '7'
+    assert result.data['relayItems']['edges'][0]['node']['id'] == 'SXRlbU5vZGU6Nw=='
+    assert result.data['relayItems']['edges'][0]['node']['parentId'] == 'SXRlbU5vZGU6Tm9uZQ=='
     assert result.data['relayItems']['edges'][0]['node']['name'] == 'foo'
 
 
@@ -161,6 +163,7 @@ def test_should_resolve_nested_variables():
                             edges {
                                 node {
                                     id
+                                    parentId
                                 }
                             }
                         }
@@ -174,4 +177,5 @@ def test_should_resolve_nested_variables():
     assert len(item_edges) == 1
     child_edges = item_edges[0]['node']['relayAllChildren']['edges'][0]
     assert len(child_edges) == 1
-    assert child_edges['node']['id'] == '8'
+    assert child_edges['node']['id'] == 'SXRlbU5vZGU6OA=='
+    assert child_edges['node']['parentId'] == 'SXRlbU5vZGU6Nw=='

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -142,13 +142,15 @@ def test_should_return_valid_result_with_prefetch_related_as_a_function():
                 foo
                 filteredChildren(name: "bar") {
                     id
+                    parentId
                     foo
                 }
             }
         }
     ''')
     assert not result.errors
-    assert result.data['items'][0]['filteredChildren'][0]['id'] == '2'
+    assert result.data['items'][0]['filteredChildren'][0]['id'] == 'SXRlbVR5cGU6Mg=='
+    assert result.data['items'][0]['filteredChildren'][0]['parentId'] == 'SXRlbVR5cGU6MQ=='
 
 
 @pytest.mark.django_db
@@ -163,10 +165,12 @@ def test_should_return_valid_result_with_prefetch_related_as_a_function_using_va
                 foo
                 filteredChildren(name: $name) {
                     id
+                    parentId
                     foo
                 }
             }
         }
     ''', variables={'name': 'bar'})
     assert not result.errors
-    assert result.data['items'][0]['filteredChildren'][0]['id'] == '2'
+    assert result.data['items'][0]['filteredChildren'][0]['id'] == 'SXRlbVR5cGU6Mg=='
+    assert result.data['items'][0]['filteredChildren'][0]['parentId'] == 'SXRlbVR5cGU6MQ=='


### PR DESCRIPTION
## The issue
The only optimization is being aborted when using the `GlobalID` as expected in Relay.

## Example
Given:
```py
from django.db import models
from graphene import relay
from graphene_django_optimizer import OptimizedDjangoObjectType


class Customer(models.Model):
    first_name = models.CharField(max_length=100)
    last_name = models.CharField(max_length=100)


class CustomerType(OptimizedDjangoObjectType):
    class Meta:
        model = Customer
        name = "Customer"
        interfaces = (relay.Node,)


class Query(graphene.ObjectType):
    customers = OptimizedConnectionField(CustomerType)
```

And performing:
```gql
{
    customers {
        edges {
            node {
                id
            }
        }
    }
}
```

The following query is executed:
```sql
SELECT
    "customer_customer"."id",
    "customer_customer"."first_name",
    "customer_customer"."last_name",
FROM
    "customer_customer";
```

Expected:
```sql
SELECT
    "customer_customer"."id"
FROM
    "customer_customer";
```